### PR TITLE
feat: Add image compression endpoint and tests

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -24,6 +24,7 @@ func New(port string) *Server {
 // It will block until the server is stopped or a fatal error occurs.
 func (s *Server) Start() {
 	http.HandleFunc("/resize", api.ResizeHandler)
+	http.HandleFunc("/compress", api.CompressHandler)
 
 	fmt.Printf("Starting server on http://localhost:%s\n", s.port)
 	log.Fatal(http.ListenAndServe(":"+s.port, nil))


### PR DESCRIPTION
This pull request adds a new image compression endpoint to the API, allowing users to upload an image and receive a JPEG-compressed version with configurable quality. It also introduces comprehensive tests for this new feature and integrates the endpoint into the server.

**New API functionality:**

* Added `CompressHandler` in `handler.go` to handle POST requests to `/compress`, accepting an uploaded image and an optional `quality` parameter (default 75, range 1–100). The handler decodes JPEG/PNG files and always returns a JPEG image.
* Registered the `/compress` route in the server startup logic (`server.go`) to make the new endpoint available.

**Testing improvements:**

* Added `TestCompressHandler` in `handler_test.go` to cover successful compression with custom, default, and invalid quality parameters, verifying status codes and handler behavior.