### PR TITLE
Staging

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,159 @@
+name: CI/CD Pipeline
+
+# Trigger only on push to main branch
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  test:
+    name: Test Backend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+          
+      - name: Run Go tests
+        run: go test -v ./...
+
+  test-frontend:
+    name: Test Frontend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+          
+      - name: Install frontend dependencies
+        working-directory: ./frontend
+        run: npm ci
+        
+      - name: Lint frontend code
+        working-directory: ./frontend
+        run: npm run lint
+        
+      - name: Build frontend
+        working-directory: ./frontend
+        run: npm run build
+
+  build-and-deploy:
+    name: Build and Deploy
+    runs-on: ubuntu-latest
+    needs: [test, test-frontend]
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Node.js for production build
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+          
+      - name: Install frontend dependencies
+        working-directory: ./frontend
+        run: npm ci
+        
+      - name: Build frontend for production
+        working-directory: ./frontend
+        run: npm run build
+      
+      - name: Build Docker image
+        run: docker build -t go-image-service:${{ github.sha }} .
+      
+      - name: Save Docker image
+        run: docker save go-image-service:${{ github.sha }} | gzip > go-image-service.tar.gz
+        
+      - name: Create frontend archive
+        run: tar -czf frontend-dist.tar.gz -C frontend/dist .
+      
+      - name: Deploy to server
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          port: ${{ secrets.SERVER_PORT }}
+          script: |
+            # Stop existing container if running
+            docker stop go-image-service || true
+            docker rm go-image-service || true
+            
+            # Remove old images to save space
+            docker image prune -f
+            
+            # Pull and run new container
+            # You can modify this section based on your deployment method
+            # Option 1: If you have a registry, pull from there
+            # docker pull your-registry/go-image-service:${{ github.sha }}
+            # docker run -d --name go-image-service -p 8080:8080 your-registry/go-image-service:${{ github.sha }}
+            
+            # Option 2: For direct deployment, you would copy the image file
+            echo "Container deployment completed"
+      
+      - name: Copy files to server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          port: ${{ secrets.SERVER_PORT }}
+          source: "go-image-service.tar.gz,frontend-dist.tar.gz"
+          target: "/tmp/"
+      
+      - name: Deploy backend and frontend
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          port: ${{ secrets.SERVER_PORT }}
+          script: |
+            # Deploy Backend (Go Service)
+            cd /tmp
+            
+            # Load the Docker image
+            docker load < go-image-service.tar.gz
+            
+            # Stop and remove existing backend container
+            docker stop go-image-service || true
+            docker rm go-image-service || true
+            
+            # Run new backend container
+            docker run -d --name go-image-service -p 8080:8080 --restart unless-stopped go-image-service:${{ github.sha }}
+            
+            # Deploy Frontend (Static Production Build)
+            # Create frontend directory if it doesn't exist
+            sudo mkdir -p /var/www/html
+            
+            # Clear existing frontend files
+            sudo rm -rf /var/www/html/*
+            
+            # Extract production-built frontend files (from Vite build)
+            cd /var/www/html
+            sudo tar -xzf /tmp/frontend-dist.tar.gz
+            
+            # Set proper permissions
+            sudo chown -R www-data:www-data /var/www/html || true
+            sudo chmod -R 755 /var/www/html
+            
+            # Clean up temporary files
+            rm /tmp/go-image-service.tar.gz
+            rm /tmp/frontend-dist.tar.gz
+            
+            # Verify deployment
+            echo "Backend deployment:"
+            sleep 3
+            docker ps | grep go-image-service
+            
+            echo "Frontend deployment:"
+            ls -la /var/www/html/

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,126 @@
+# CI/CD Pipeline Setup
+
+This repository includes a GitHub Actions workflow that automatically deploys both your Go backend service and React frontend to a remote server when code is pushed to the `main` branch.
+
+## Required GitHub Secrets
+
+You need to configure the following secrets in your GitHub repository settings (`Settings > Secrets and variables > Actions`):
+
+### Server Configuration
+- `SERVER_HOST`: The IP address or hostname of your remote server
+- `SERVER_USER`: The username to SSH into your server (e.g., `ubuntu`, `root`)
+- `SERVER_SSH_KEY`: The private SSH key for accessing your server
+- `SERVER_PORT`: The SSH port (usually `22`)
+
+## How to Set Up Secrets
+
+1. Go to your GitHub repository
+2. Click on `Settings` tab
+3. In the left sidebar, click `Secrets and variables` > `Actions`
+4. Click `New repository secret` for each secret above
+
+### SSH Key Setup
+
+1. Generate an SSH key pair on your local machine:
+   ```bash
+   ssh-keygen -t rsa -b 4096 -f ~/.ssh/deploy_key
+   ```
+
+2. Copy the public key to your server:
+   ```bash
+   ssh-copy-id -i ~/.ssh/deploy_key.pub user@your-server-ip
+   ```
+
+3. Copy the private key content and add it as `SERVER_SSH_KEY` secret:
+   ```bash
+   cat ~/.ssh/deploy_key
+   ```
+
+## Pipeline Process
+
+The CI/CD pipeline will:
+
+1. **Test Backend**: Run Go tests to ensure backend code quality
+2. **Test Frontend**: Install dependencies, lint, and build React frontend
+3. **Build & Deploy**: 
+   - Build frontend production assets
+   - Build Docker image for Go backend
+   - Copy both frontend and backend to your server
+   - Deploy backend container on port 8080
+   - Deploy frontend to `/var/www/html`
+   - Verify both deployments
+
+## Server Requirements
+
+Your remote server needs:
+- Docker installed
+- Nginx installed (for serving frontend)
+- SSH access enabled
+- Port 80 (frontend) and 8080 (backend API) available
+
+### Server Setup Commands
+
+Run these commands on your server to prepare for deployment:
+
+```bash
+# Install Docker
+curl -fsSL https://get.docker.com -o get-docker.sh
+sudo sh get-docker.sh
+
+# Install Nginx
+sudo apt update
+sudo apt install nginx -y
+
+# Create web directory
+sudo mkdir -p /var/www/html
+
+# Copy the nginx configuration
+sudo cp nginx.conf /etc/nginx/sites-available/default
+sudo nginx -t
+sudo systemctl restart nginx
+sudo systemctl enable nginx
+
+# Open firewall ports
+sudo ufw allow 80
+sudo ufw allow 8080
+```
+
+## Architecture
+
+- **Frontend**: React/Vite app **built to static files** and served by Nginx on port 80
+- **Backend**: Go service running in Docker on port 8080  
+- **API Proxy**: Nginx proxies `/api/*` requests to the Go backend
+
+### Production Frontend Deployment
+
+The frontend is **NOT** running as a Vite dev server in production. Instead:
+
+1. **Build Phase**: `npm run build` creates optimized static files in `frontend/dist/`
+2. **Deploy Phase**: Static files are extracted to `/var/www/html/` 
+3. **Serve Phase**: Nginx serves these static files directly (no Node.js process running)
+
+This is the correct production approach for React/Vite applications.
+
+## Manual Testing
+
+### Backend
+```bash
+# Build and test backend
+docker build -t go-image-service:latest .
+docker run -d --name go-image-service -p 8080:8080 go-image-service:latest
+curl http://localhost:8080/api/health
+```
+
+### Frontend
+```bash
+# Build and test frontend
+cd frontend
+npm install
+npm run build
+npm run preview
+```
+
+### Full Stack
+- Frontend: http://your-server-ip (port 80)
+- Backend API: http://your-server-ip:8080
+- API through proxy: http://your-server-ip/api/

--- a/README.md
+++ b/README.md
@@ -21,32 +21,32 @@ The service exposes several endpoints for image manipulation. All endpoints expe
 - **`/resize`**: Resizes an image.
     - **Query Params**: `width` (int), `height` (int)
     - **Behavior**: Preserves aspect ratio if one dimension is omitted. Uses a default width of 500px if both are omitted.
-    - **Example**: `curl -X POST -F "image=@/path/to/img.png" "http://localhost:8080/resize?width=300"`
+    - **Example**: `curl -X POST -F "image=@/path/to/img.png" "http://localhost:8080/api/resize?width=300"`
 
 - **`/compress`**: Adjusts the quality of a JPEG image.
     - **Query Params**: `quality` (int, 1-100)
     - **Behavior**: Outputs a JPEG. Defaults to quality `75` if the parameter is missing or invalid.
-    - **Example**: `curl -X POST -F "image=@/path/to/img.png" "http://localhost:8080/compress?quality=50"`
+    - **Example**: `curl -X POST -F "image=@/path/to/img.png" "http://localhost:8080/api/compress?quality=50"`
 
 - **`/convert`**: Converts an image from one format to another.
     - **Query Params**: `format` (string, "jpeg" or "png")
     - **Behavior**: Fails if the format is missing or unsupported.
-    - **Example**: `curl -X POST -F "image=@/path/to/img.jpg" "http://localhost:8080/convert?format=png"`
+    - **Example**: `curl -X POST -F "image=@/path/to/img.jpg" "http://localhost:8080/api/convert?format=png"`
 
 - **`/flip`**: Flips an image.
     - **Query Params**: `direction` (string, "horizontal" or "vertical")
     - **Behavior**: Fails if the direction is missing or invalid.
-    - **Example**: `curl -X POST -F "image=@/path/to/img.png" "http://localhost:8080/flip?direction=horizontal"`
+    - **Example**: `curl -X POST -F "image=@/path/to/img.png" "http://localhost:8080/api/flip?direction=horizontal"`
 
 - **`/rotate`**: Rotates an image by a 90-degree increment.
     - **Query Params**: `angle` (int, 90, 180, or 270)
     - **Behavior**: Fails if the angle is missing or unsupported.
-    - **Example**: `curl -X POST -F "image=@/path/to/img.png" "http://localhost:8080/rotate?angle=90"`
+    - **Example**: `curl -X POST -F "image=@/path/to/img.png" "http://localhost:8080/api/rotate?angle=90"`
 
 - **`/crop`**: Crops an image to a specified rectangle.
     - **Query Params**: `x` (int), `y` (int), `width` (int), `height` (int)
     - **Behavior**: Fails if any parameter is missing or invalid.
-    - **Example**: `curl -X POST -F "image=@/path/to/img.png" "http://localhost:8080/crop?x=10&y=10&width=100&height=100"`
+    - **Example**: `curl -X POST -F "image=@/path/to/img.png" "http://localhost:8080/api/crop?x=10&y=10&width=100&height=100"`
 
 ## Setup and Run Instructions
 

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.25 AS builder
+
+WORKDIR /go_app
+
+COPY go.mod go.sum ./
+
+RUN go mod download
+
+COPY . .
+
+RUN go build -v -o /go_app/cmd/api/main ./...
+
+CMD [ "/go_app/cmd/api/main" ]

--- a/dockerfile
+++ b/dockerfile
@@ -1,13 +1,32 @@
+# Stage 1: Builder
+# This stage uses the Go image to build the application.
 FROM golang:1.25 AS builder
 
-WORKDIR /go_app
+# Set the working directory inside the container
+WORKDIR /app
 
+# Copy go.mod and go.sum to download dependencies first
+# This leverages Docker's layer caching.
 COPY go.mod go.sum ./
-
 RUN go mod download
 
+# Copy the rest of the application's source code
 COPY . .
 
-RUN go build -v -o /go_app/cmd/api/main ./...
+# Build the Go application as a static binary
+# CGO_ENABLED=0 is important for creating a static binary that can run in a scratch image.
+# The output is a single binary file named 'server' in the /app directory.
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o /app/server ./cmd/api
 
-CMD [ "/go_app/cmd/api/main" ]
+# Stage 2: Final
+# This stage creates the final, small production image.
+FROM scratch
+
+# Copy only the compiled binary from the builder stage
+COPY --from=builder /app/server /server
+
+# Expose the port the application runs on
+EXPOSE 8080
+
+# Set the command to run the executable
+CMD ["/server"]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>GIPS - Go Image Processing Service</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/frontend/src/pages/CompressPage.tsx
+++ b/frontend/src/pages/CompressPage.tsx
@@ -29,7 +29,7 @@ const CompressPage = () => {
     setError(null);
     const formData = new FormData();
     formData.append('image', selectedFile);
-    const apiUrl = `http://localhost:8080/compress?quality=${quality}`;
+    const apiUrl = `http://localhost:8080/api/compress?quality=${quality}`;
     try {
       const response = await fetch(apiUrl, { method: 'POST', body: formData });
       if (!response.ok) {

--- a/frontend/src/pages/ConvertPage.tsx
+++ b/frontend/src/pages/ConvertPage.tsx
@@ -27,7 +27,7 @@ const Converter = () => {
     const formData = new FormData();
     formData.append('image', selectedFile);
 
-    const apiUrl = `http://localhost:8080/convert?format=${targetFormat}`;
+    const apiUrl = `http://localhost:8080/api/convert?format=${targetFormat}`;
 
     try {
       const response = await fetch(apiUrl, { method: 'POST', body: formData });

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -12,6 +12,13 @@ import (
 	"github.com/disintegration/gift"
 )
 
+// HealthCheckHandler responds with a simple "OK" message to indicate the service is running.
+// It can be used for health checks by load balancers or orchestration systems.
+func HealthCheckHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("OK"))
+}
+
 // ResizeHandler processes an image uploaded via a multipart form and resizes it.
 //
 // It expects a POST request with a form field named "image" containing the image file.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -24,7 +24,10 @@ func New(port string) *Server {
 // It will block until the server is stopped or a fatal error occurs.
 func (s *Server) Start() {
 	// Create a new mux (router)
+	rootMux := http.NewServeMux()
 	mux := http.NewServeMux()
+
+	mux.HandleFunc("/health", api.HealthCheckHandler)
 	mux.HandleFunc("/resize", api.ResizeHandler)
 	mux.HandleFunc("/compress", api.CompressHandler)
 	mux.HandleFunc("/convert", api.ConvertHandler)
@@ -32,8 +35,10 @@ func (s *Server) Start() {
 	mux.HandleFunc("/rotate", api.RotateHandler)
 	mux.HandleFunc("/crop", api.CropHandler)
 
+	rootMux.Handle("/api/", http.StripPrefix("/api", mux))
+
 	// Wrap the mux with a CORS middleware
-	h := corsMiddleware(mux)
+	h := corsMiddleware(rootMux)
 
 	fmt.Printf("Starting server on http://localhost:%s\n", s.port)
 	log.Fatal(http.ListenAndServe(":"+s.port, h))

--- a/nginx_custom.conf
+++ b/nginx_custom.conf
@@ -1,0 +1,27 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /var/www/html;
+    index index.html;
+
+    # Serve frontend static files
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Proxy API requests to Go backend
+    location /api/ {
+        proxy_pass http://localhost:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Handle static assets with caching
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+}


### PR DESCRIPTION
This pull request introduces a comprehensive CI/CD pipeline and deployment architecture for the Go backend and React frontend, standardizes API routing, and adds documentation and configuration for production deployment. The changes ensure that both backend and frontend are automatically built, tested, and deployed to a remote server on pushes to the `main` branch, and that API endpoints are consistently routed through `/api/`. Below are the most important changes grouped by theme.

**CI/CD Pipeline and Deployment Automation**

* Added a GitHub Actions workflow (`.github/workflows/ci-cd.yml`) that tests, builds, and deploys both backend and frontend to a remote server using Docker and SSH/SCP actions.
* Created a detailed deployment guide (`DEPLOYMENT.md`) outlining required secrets, server setup, pipeline steps, and manual testing instructions.

**Production Configuration**

* Added a multi-stage Dockerfile (`dockerfile`) that builds the Go backend as a static binary and produces a minimal final image for deployment.
* Provided a custom Nginx configuration (`nginx_custom.conf`) to serve the frontend and proxy `/api/` requests to the Go backend, including caching for static assets.

**API Routing and Documentation**

* Updated backend server routing so all API endpoints are now under `/api/`, and added a `/api/health` endpoint for health checks. [[1]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23R27-R41) [[2]](diffhunk://#diff-4557c0feb4807d067dd963ec1a7d19ad62c17d2ebce2afb769ca83c6c9c58250R15-R21)
* Standardized frontend and documentation API calls to use `/api/` prefix, updating example URLs and fetch requests in both `README.md` and frontend code. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L24-R49) [[2]](diffhunk://#diff-4458b62fd0653a8a0811b967f6700ebf5d462395dcc35c36ca2d9b9ef248fd98L32-R32) [[3]](diffhunk://#diff-ff6a6d7f3dc78af01d002ac20a461ff7f9acad022b789ead584a6910891fd558L30-R30)

**Minor Frontend Fix**

* Removed the default Vite favicon reference from `frontend/index.html` for a cleaner production build.