### PR TITLE
feat: Remove frontend linting step from CI/CD pipeline

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -37,10 +37,6 @@ jobs:
         working-directory: ./frontend
         run: npm ci
         
-      - name: Lint frontend code
-        working-directory: ./frontend
-        run: npm run lint
-        
       - name: Build frontend
         working-directory: ./frontend
         run: npm run build


### PR DESCRIPTION
This pull request makes a minor adjustment to the CI/CD workflow by removing the linting step for the frontend code.

* Removed the "Lint frontend code" step from the CI/CD pipeline in `.github/workflows/ci-cd.yml`.